### PR TITLE
Descriptor rework

### DIFF
--- a/src/command/list/bundle.rs
+++ b/src/command/list/bundle.rs
@@ -64,18 +64,18 @@ pub struct BundleRecording<'a> {
 impl<'a> BundleRecording<'a> {
     // TODO: double check descriptor heap settings
     #[inline]
-    pub fn set_descriptor_heaps(
-        &mut self, cbv_srv_uav_heap: Option<&CbvSrvUavHeap>,
-        sampler_heap: Option<&SamplerHeap>
+    pub fn set_descriptor_heaps<T: CsuHeap, S: SamplerHeap>(
+        &mut self, cbv_srv_uav_heap: Option<&mut T>,
+        sampler_heap: Option<&mut S>
     ) {
         let mut heaps = [
             ::std::ptr::null_mut(), ::std::ptr::null_mut(),
         ];
         if let Some(heap) = cbv_srv_uav_heap {
-            heaps[1] = heap.ptr.as_mut_ptr();
+            heaps[1] = heap.as_raw_ptr().as_mut_ptr();
         }
         if let Some(heap) = sampler_heap {
-            heaps[0] = heap.ptr.as_mut_ptr();
+            heaps[0] = heap.as_raw_ptr().as_mut_ptr();
         }
         unsafe {
             self.ptr.SetDescriptorHeaps(2, heaps.as_mut_ptr())

--- a/src/command/list/bundle.rs
+++ b/src/command/list/bundle.rs
@@ -65,32 +65,20 @@ impl<'a> BundleRecording<'a> {
     // TODO: double check descriptor heap settings
     #[inline]
     pub fn set_descriptor_heaps(
-        mut self, cbv_srv_uav_heap: Option<&CbvSrvUavHeap>,
-        rtv_heap: Option<&RtvHeap>, dsv_heap: Option<&DsvHeap>,
+        &mut self, cbv_srv_uav_heap: Option<&CbvSrvUavHeap>,
         sampler_heap: Option<&SamplerHeap>
-    ) -> BundleRecordingWithHeap<'a> {
+    ) {
         let mut heaps = [
-            ::std::ptr::null_mut(), ::std::ptr::null_mut(),
             ::std::ptr::null_mut(), ::std::ptr::null_mut(),
         ];
         if let Some(heap) = cbv_srv_uav_heap {
-            heaps[0] = heap.ptr.as_mut_ptr();
-        }
-        if let Some(heap) = rtv_heap {
             heaps[1] = heap.ptr.as_mut_ptr();
         }
-        if let Some(heap) = dsv_heap {
-            heaps[2] = heap.ptr.as_mut_ptr();
-        }
         if let Some(heap) = sampler_heap {
-            heaps[3] = heap.ptr.as_mut_ptr();
+            heaps[0] = heap.ptr.as_mut_ptr();
         }
         unsafe {
-            self.ptr.SetDescriptorHeaps(4, heaps.as_mut_ptr());
-        }
-        
-        BundleRecordingWithHeap{
-            ptr: self.ptr, alloc: self.alloc
+            self.ptr.SetDescriptorHeaps(2, heaps.as_mut_ptr())
         }
     }
 

--- a/src/command/list/direct.rs
+++ b/src/command/list/direct.rs
@@ -86,8 +86,8 @@ impl<'a> DirectCommandListRecording<'a> {
     }
 
     /// record a command to clear uav. [more info](https://msdn.microsoft.com/zh-cn/library/windows/desktop/dn903849(v=vs.85).aspx)
-    pub fn clear_uav_f32(
-        &mut self, heap: &mut CbvSrvUavHeap, index: u32,
+    pub fn clear_uav_f32<T: CsuHeap>(
+        &mut self, heap: &mut T, index: u32,
         resource: &mut RawResource, values: &[f32; 4],
         rects: Option<&[::format::Rect]>
     ) {
@@ -108,8 +108,8 @@ impl<'a> DirectCommandListRecording<'a> {
     }
 
     /// record a command to clear uav. [more info](https://msdn.microsoft.com/zh-cn/library/windows/desktop/dn903849(v=vs.85).aspx)
-    pub fn clear_uav_u32(
-        &mut self, heap: &mut CbvSrvUavHeap, index: u32,
+    pub fn clear_uav_u32<T: CsuHeap>(
+        &mut self, heap: &mut T, index: u32,
         resource: &mut RawResource, values: &[u32; 4],
         rects: Option<&[::format::Rect]>
     ) {
@@ -275,18 +275,18 @@ impl<'a> DirectCommandListRecording<'a> {
 
     // TODO: double check descriptor heap settings
     #[inline]
-    pub fn set_descriptor_heaps(
-        &mut self, cbv_srv_uav_heap: Option<&CbvSrvUavHeap>,
-        sampler_heap: Option<&SamplerHeap>
+    pub fn set_descriptor_heaps<T: CsuHeap, S: SamplerHeap>(
+        &mut self, cbv_srv_uav_heap: Option<&mut T>,
+        sampler_heap: Option<&mut S>
     ) {
         let mut heaps = [
             ::std::ptr::null_mut(), ::std::ptr::null_mut(),
         ];
         if let Some(heap) = cbv_srv_uav_heap {
-            heaps[1] = heap.ptr.as_mut_ptr();
+            heaps[1] = heap.as_raw_ptr().as_mut_ptr();
         }
         if let Some(heap) = sampler_heap {
-            heaps[0] = heap.ptr.as_mut_ptr();
+            heaps[0] = heap.as_raw_ptr().as_mut_ptr();
         }
         unsafe {
             self.ptr.SetDescriptorHeaps(2, heaps.as_mut_ptr())

--- a/src/command/list/direct.rs
+++ b/src/command/list/direct.rs
@@ -277,27 +277,19 @@ impl<'a> DirectCommandListRecording<'a> {
     #[inline]
     pub fn set_descriptor_heaps(
         &mut self, cbv_srv_uav_heap: Option<&CbvSrvUavHeap>,
-        rtv_heap: Option<&RtvHeap>, dsv_heap: Option<&DsvHeap>,
         sampler_heap: Option<&SamplerHeap>
     ) {
         let mut heaps = [
             ::std::ptr::null_mut(), ::std::ptr::null_mut(),
-            ::std::ptr::null_mut(), ::std::ptr::null_mut(),
         ];
         if let Some(heap) = cbv_srv_uav_heap {
-            heaps[0] = heap.ptr.as_mut_ptr();
-        }
-        if let Some(heap) = rtv_heap {
             heaps[1] = heap.ptr.as_mut_ptr();
         }
-        if let Some(heap) = dsv_heap {
-            heaps[2] = heap.ptr.as_mut_ptr();
-        }
         if let Some(heap) = sampler_heap {
-            heaps[3] = heap.ptr.as_mut_ptr();
+            heaps[0] = heap.ptr.as_mut_ptr();
         }
         unsafe {
-            self.ptr.SetDescriptorHeaps(4, heaps.as_mut_ptr())
+            self.ptr.SetDescriptorHeaps(2, heaps.as_mut_ptr())
         }
     }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -18,7 +18,7 @@ use resource::*;
 use pipeline::rootsig::{RootSig, RootSigDescBlob};
 use pipeline::{PipelineState, GraphicsPipelineStateBuilder};
 use fence::{Fence, FenceFlags};
-use descriptor::{CbvSrvUavHeap, RtvHeap, DsvHeap, SamplerHeap, DescriptorHeapBuilder};
+use descriptor::{CsuHeapSv, CsuHeapNsv, RtvHeap, DsvHeap, SamplerHeapSv, SamplerHeapNsv};
 
 /// a 3D display adapter
 #[derive(Debug, Clone)]
@@ -237,26 +237,6 @@ impl Device {
         }
     }
 
-    #[inline]
-    pub fn create_cbv_srv_uav_heap(&mut self, builder: &DescriptorHeapBuilder) -> Result<CbvSrvUavHeap, WinError> {
-        builder.build_cbv_srv_uav_heap(self)
-    }
-
-    #[inline]
-    pub fn create_rtv_heap(&mut self, builder: &DescriptorHeapBuilder) -> Result<RtvHeap, WinError> {
-        builder.build_rtv_heap(self)
-    }
-
-    #[inline]
-    pub fn create_dsv_heap(&mut self, builder: &DescriptorHeapBuilder) -> Result<DsvHeap, WinError> {
-        builder.build_dsv_heap(self)
-    }
-
-    #[inline]
-    pub fn create_sampler_heap(&mut self, builder: &DescriptorHeapBuilder) -> Result<SamplerHeap, WinError> {
-        builder.build_sampler_heap(self)
-    }
-
     // TODO: copy or compute command lists?
     #[inline]
     pub fn create_direct_command_list<'a>(
@@ -367,10 +347,12 @@ impl_device_child!(BundleCommandAllocator, ptr);
 impl_device_child!(Heap, ptr);
 impl_device_child!(RawResource, ptr);
 impl_device_child!(Fence, ptr);
-impl_device_child!(CbvSrvUavHeap, ptr);
+impl_device_child!(CsuHeapSv, ptr);
+impl_device_child!(CsuHeapNsv, ptr);
 impl_device_child!(DsvHeap, ptr);
 impl_device_child!(RtvHeap, ptr);
-impl_device_child!(SamplerHeap, ptr);
+impl_device_child!(SamplerHeapSv, ptr);
+impl_device_child!(SamplerHeapNsv, ptr);
 impl_device_child!(DirectCommandList, ptr);
 impl_device_child!(Bundle, ptr);
 impl_device_child!(PipelineState, ptr);

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -204,7 +204,9 @@ bitflags!{
         const RESOURCE_STATE_INDEX_BUFFER                = 0x2;
         /// a subresource should be in this state when used as a render target
         const RESOURCE_STATE_RENDER_TARGET               = 0x4;
-        /// a subresource should be in this state when accessed via an UAV
+        /// a subresource should be in this state when accessed via an UAV.
+        /// when in this state, a resource can be accessed for RW from multiple
+        /// command queues simultaneously.
         const RESOURCE_STATE_UNORDERED_ACCESS            = 0x8;
         /// a subresource should be in this state when used for depth write. mutual exclusive
         const RESOURCE_STATE_DEPTH_WRITE                 = 0x10;
@@ -226,7 +228,9 @@ bitflags!{
         const RESOURCE_STATE_RESOLVE_DEST                = 0x1000;
         /// used as the src in a resolve operation
         const RESOURCE_STATE_RESOLVE_SOURCE              = 0x2000;
-        /// required starting state for upload heaps
+        /// required starting state for upload heaps.
+        /// when in this state, a resource can be accessed for reading from
+        /// multiple command queues simultaneously.
         const RESOURCE_STATE_GENERIC_READ = ((((0x1|0x2)|0x40)|0x80)|0x200)|0x800;
         /// alias for `COMMON`
         const RESOURCE_STATE_PRESENT                     = 0;


### PR DESCRIPTION
MSDN pointed out that it is illegal to use a shader visible descriptor heap as copy sources. This PR introduces shader visibility as type level to ensure that such illegal invocation would never occur.